### PR TITLE
New rule: AvoidUsingObjectMapperAsALocalVariable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -253,6 +253,8 @@
                 <exclude>dependencies:org.llorllale:cactoos-matchers</exclude>
                 <exclude>dependencies:org.openjdk.jmh</exclude>
                 <exclude>org.junit.jupiter:junit-jupiter-api</exclude>
+                <exclude>dependencies:net.sourceforge.pmd:pmd-core</exclude>
+                <exclude>dependencies:net.sourceforge.pmd:pmd-java</exclude>
               </excludes>
             </configuration>
             <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,7 @@
     <sonar.version>3.4.0.905</sonar.version>
     <commons-logging.version>1.2</commons-logging.version>
     <!-- General dependencies -->
+    <pmd.rules.version>6.41.0</pmd.rules.version>
     <cactoos.version>0.50</cactoos.version>
     <!-- Testing -->
     <hamcrest.version>2.2</hamcrest.version>
@@ -152,6 +153,29 @@
       <artifactId>jmh-generator-annprocess</artifactId>
       <version>${jmh.version}</version>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>net.sourceforge.pmd</groupId>
+      <artifactId>pmd-core</artifactId>
+      <version>${pmd.rules.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>net.sourceforge.pmd</groupId>
+      <artifactId>pmd-java</artifactId>
+      <version>${pmd.rules.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>net.sourceforge.pmd</groupId>
+      <artifactId>pmd-test</artifactId>
+      <version>${pmd.rules.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- Dependencies needed in tests -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.13.1</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
   <groupId>io.github.dgroup</groupId>
   <artifactId>arch4u-pmd</artifactId>
   <!-- @todo #/DEV Write minimalistic/laconic project overview in readme.md -->
-  <version>0.0.0</version>
+  <version>0.1.0</version>
   <!-- @todo #/DEV Setup code code quality 3rd-party services and add badge to the readme.md -->
   <packaging>jar</packaging>
   <name>${project.artifactId}</name>

--- a/src/main/resources/io/github/dgroup/arch4u/pmd/default-ruleset.xml
+++ b/src/main/resources/io/github/dgroup/arch4u/pmd/default-ruleset.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0"?>
+
+<ruleset name="Default"
+         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
+         xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
+
+  <description>Default ruleset</description>
+
+  <rule name="AvoidUsingObjectMapperAsALocalVariable"
+        since="0.1.0"
+        language="java"
+        message="ObjectMapper is better to have as field than a local variable due to performance reasons."
+        class="net.sourceforge.pmd.lang.rule.XPathRule">
+        <description>
+          ObjectMapper is better to have as field than a local variable due to performance reasons.
+          It is allowed to be declared in fields, constructors and initialization blocks.
+        </description>
+        <priority>3</priority>
+        <properties>
+            <property name="version" value="2.0"/>
+            <property name="xpath">
+                <value>
+<![CDATA[
+//
+(
+Type/ReferenceType (: variable declaration :)
+|
+AllocationExpression (: constr invocation :)
+)
+/ClassOrInterfaceType
+[pmd-java:typeIs('com.fasterxml.jackson.databind.ObjectMapper')]
+[not(
+ancestor::FieldDeclaration (: skip fields :)
+or ancestor::Initializer   (: skip init blocks :)
+or ancestor::ConstructorDeclaration (: skip constructor blocks :)
+)]
+/.. (: violation points to the parent node :)
+]]>
+                </value>
+            </property>
+        </properties>
+        <example>
+<![CDATA[
+import com.fasterxml.jackson.databind.ObjectMapper;
+class Foo {
+    ObjectMapper objectMapper = new ObjectMapper(); //ok
+
+    {
+        objectMapper = new ObjectMapper();  //ok
+    }
+
+    Foo (ObjectMapper om) {                 //ok
+        objectMapper = new ObjectMapper();  //ok
+    }
+
+    void bar(ObjectMapper om) {                                  //violation
+        ObjectMapper mapper = om;                                //violation
+        mapper = new ObjectMapper();                             //violation
+        String str = new ObjectMapper().writeValueAsString(obj); //violation
+    }
+}
+]]>
+        </example>
+    </rule>
+</ruleset>

--- a/src/test/java/io/github/dgroup/arch4u/pmd/AvoidUsingObjectMapperAsALocalVariableTest.java
+++ b/src/test/java/io/github/dgroup/arch4u/pmd/AvoidUsingObjectMapperAsALocalVariableTest.java
@@ -1,0 +1,44 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019-2022 Yurii Dubinka
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom
+ * the Software is  furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ * OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.dgroup.arch4u.pmd;
+
+import net.sourceforge.pmd.testframework.SimpleAggregatorTst;
+
+/**
+ * Test case for {@code AvoidUsingObjectMapperAsALocalVariable} rule.
+ *
+ * @since 0.1.0
+ */
+@SuppressWarnings({"PMD.TestClassWithoutTestCases", "PMD.JUnit4TestShouldUseBeforeAnnotation"})
+public final class AvoidUsingObjectMapperAsALocalVariableTest extends SimpleAggregatorTst {
+
+    @Override
+    public void setUp() {
+        addRule(
+            "io/github/dgroup/arch4u/pmd/default-ruleset.xml",
+            "AvoidUsingObjectMapperAsALocalVariable"
+        );
+    }
+}

--- a/src/test/java/io/github/dgroup/arch4u/pmd/package-info.java
+++ b/src/test/java/io/github/dgroup/arch4u/pmd/package-info.java
@@ -1,0 +1,31 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019-2022 Yurii Dubinka
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom
+ * the Software is  furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ * OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * Test cases for the {@link io.github.dgroup.arch4u.pmd} package.
+ *
+ * @author Oleksii Dykov (dykovoleksii@gmail.com)
+ * @since 0.1.0
+ */
+package io.github.dgroup.arch4u.pmd;

--- a/src/test/resources/io/github/dgroup/arch4u/pmd/xml/AvoidUsingObjectMapperAsALocalVariable.xml
+++ b/src/test/resources/io/github/dgroup/arch4u/pmd/xml/AvoidUsingObjectMapperAsALocalVariable.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data
+    xmlns="http://pmd.sourceforge.net/rule-tests"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests https://pmd.sourceforge.io/rule-tests_1_0_0.xsd">
+
+  <test-code>
+    <description>[GOOD]: allowed ObjectMapper usage</description>
+    <expected-problems>0</expected-problems>
+    <code><![CDATA[
+import com.fasterxml.jackson.databind.ObjectMapper;
+public class Foo {
+    ObjectMapper objectMapper = new ObjectMapper();   //ok
+
+    {
+        objectMapper = new ObjectMapper();    //ok
+    }
+
+    Foo (ObjectMapper om) {                   //ok
+        objectMapper = new ObjectMapper();    //ok
+    }
+}
+        ]]></code>
+  </test-code>
+
+  <test-code>
+    <description>[BAD]: prohibited ObjectMapper usage</description>
+    <expected-problems>4</expected-problems>
+    <expected-linenumbers>3, 4, 5, 6</expected-linenumbers>
+    <code><![CDATA[
+import com.fasterxml.jackson.databind.ObjectMapper;
+public class Foo {
+    public void bar(ObjectMapper om) {                           //violation
+        ObjectMapper mapper = om;                                //violation
+        mapper = new ObjectMapper();                             //violation
+        String str = new ObjectMapper().writeValueAsString(obj); //violation
+    }
+}
+        ]]></code>
+  </test-code>
+
+  <test-code>
+    <description>[BAD]: prohibited JsonMapper (inherited from ObjectMapper) usage</description>
+    <expected-problems>1</expected-problems>
+    <expected-linenumbers>4</expected-linenumbers>
+    <code><![CDATA[
+import com.fasterxml.jackson.databind.json.JsonMapper;
+public class Foo {
+    public void bar() {
+        JsonMapper mapper;    //violation
+    }
+}
+        ]]></code>
+  </test-code>
+</test-data>


### PR DESCRIPTION
# Description
A new rule has been implemented to avoid using ObjectMapper not as a class field:
```java
import com.fasterxml.jackson.databind.ObjectMapper;
class Foo {
    ObjectMapper objectMapper = new ObjectMapper(); //ok
    {
        objectMapper = new ObjectMapper();  //ok
    }
    Foo (ObjectMapper om) {                 //ok
        objectMapper = new ObjectMapper();  //ok
    }

    void bar(ObjectMapper om) {                                  //violation
        ObjectMapper mapper = om;                                //violation
        mapper = new ObjectMapper();                             //violation
        String str = new ObjectMapper().writeValueAsString(obj); //violation
    }
}
```

# Completed work
- [x] Added new rule
- [x] Added new unit tests
- [x] Passed all checks

# Related issues: 
Implements #2 