### PR TITLE
New rule: NoMandatoryConstructorInExceptionClass

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
   <groupId>io.github.dgroup</groupId>
   <artifactId>arch4u-pmd</artifactId>
   <!-- @todo #/DEV Write minimalistic/laconic project overview in readme.md -->
-  <version>0.1.0</version>
+  <version>0.2.0</version>
   <!-- @todo #/DEV Setup code code quality 3rd-party services and add badge to the readme.md -->
   <packaging>jar</packaging>
   <name>${project.artifactId}</name>

--- a/src/main/resources/io/github/dgroup/arch4u/pmd/default-ruleset.xml
+++ b/src/main/resources/io/github/dgroup/arch4u/pmd/default-ruleset.xml
@@ -13,15 +13,15 @@
         language="java"
         message="ObjectMapper is better to have as field than a local variable due to performance reasons."
         class="net.sourceforge.pmd.lang.rule.XPathRule">
-        <description>
-          ObjectMapper is better to have as field than a local variable due to performance reasons.
-          It is allowed to be declared in fields, constructors and initialization blocks.
-        </description>
-        <priority>3</priority>
-        <properties>
-            <property name="version" value="2.0"/>
-            <property name="xpath">
-                <value>
+    <description>
+      ObjectMapper is better to have as field than a local variable due to performance reasons.
+      It is allowed to be declared in fields, constructors and initialization blocks.
+    </description>
+    <priority>3</priority>
+    <properties>
+      <property name="version" value="2.0"/>
+      <property name="xpath">
+        <value>
 <![CDATA[
 //
 (
@@ -38,10 +38,10 @@ or ancestor::ConstructorDeclaration (: skip constructor blocks :)
 )]
 /.. (: violation points to the parent node :)
 ]]>
-                </value>
-            </property>
-        </properties>
-        <example>
+        </value>
+      </property>
+    </properties>
+    <example>
 <![CDATA[
 import com.fasterxml.jackson.databind.ObjectMapper;
 class Foo {
@@ -62,6 +62,53 @@ class Foo {
     }
 }
 ]]>
-        </example>
-    </rule>
+    </example>
+  </rule>
+
+  <rule name="NoMandatoryConstructorInExceptionClass"
+        since="0.2.0"
+        language="java"
+        message="Exception class must have at least one constructor with signature `public Ctor(Throwable, String, Object...)` or `public Ctor(String, Object...)`."
+        class="net.sourceforge.pmd.lang.rule.XPathRule">
+    <description>
+      Exception class must have at least one constructor with signature
+      `public Ctor(Throwable, String, Object...)` or `public Ctor(String, Object...)`.
+    </description>
+    <priority>3</priority>
+    <properties>
+      <property name="version" value="2.0"/>
+      <property name="xpath">
+        <value>
+<![CDATA[
+//ClassOrInterfaceDeclaration
+[pmd-java:typeIs('java.lang.Exception')] (: extends Exception class :)
+[not(
+./ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/ConstructorDeclaration[@Public=true()]
+/FormalParameters[
+    (: Ctor(Throwable, String, Object...) :)
+    (./FormalParameter[1]/Type/ReferenceType/ClassOrInterfaceType[pmd-java:typeIsExactly('java.lang.Throwable')]
+    and
+    ./FormalParameter[2]/Type/ReferenceType/ClassOrInterfaceType[pmd-java:typeIs('java.lang.String')]
+    and
+    ./FormalParameter[3][@Varargs=true()]/Type/ReferenceType/ClassOrInterfaceType[pmd-java:typeIsExactly('java.lang.Object')])
+    or
+    (: Ctor(String, Object...) :)
+    (./FormalParameter[1]/Type/ReferenceType/ClassOrInterfaceType[pmd-java:typeIs('java.lang.String')]
+    and
+    ./FormalParameter[2][@Varargs=true()]/Type/ReferenceType/ClassOrInterfaceType[pmd-java:typeIsExactly('java.lang.Object')])]
+)]
+]]>
+        </value>
+      </property>
+    </properties>
+    <example>
+<![CDATA[
+class MyException extends Exception {
+    public MyException(String pattern, Object... args) {}
+
+    public MyException(Throwable cause, String pattern, Object... args) {}
+}
+]]>
+    </example>
+  </rule>
 </ruleset>

--- a/src/test/java/io/github/dgroup/arch4u/pmd/NoMandatoryConstructorInExceptionClassTest.java
+++ b/src/test/java/io/github/dgroup/arch4u/pmd/NoMandatoryConstructorInExceptionClassTest.java
@@ -1,0 +1,44 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019-2022 Yurii Dubinka
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom
+ * the Software is  furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ * OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.dgroup.arch4u.pmd;
+
+import net.sourceforge.pmd.testframework.SimpleAggregatorTst;
+
+/**
+ * Test case for {@code NoMandatoryConstructorInExceptionClass} rule.
+ *
+ * @since 0.2.0
+ */
+@SuppressWarnings({"PMD.TestClassWithoutTestCases", "PMD.JUnit4TestShouldUseBeforeAnnotation"})
+public final class NoMandatoryConstructorInExceptionClassTest extends SimpleAggregatorTst {
+
+    @Override
+    public void setUp() {
+        addRule(
+            "io/github/dgroup/arch4u/pmd/default-ruleset.xml",
+            "NoMandatoryConstructorInExceptionClass"
+        );
+    }
+}

--- a/src/test/resources/io/github/dgroup/arch4u/pmd/xml/AvoidUsingObjectMapperAsALocalVariable.xml
+++ b/src/test/resources/io/github/dgroup/arch4u/pmd/xml/AvoidUsingObjectMapperAsALocalVariable.xml
@@ -1,4 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ MIT License
+  ~
+  ~ Copyright (c) 2019-2022 Yurii Dubinka
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"),
+  ~ to deal in the Software without restriction, including without limitation
+  ~ the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  ~ and/or sell copies of the Software, and to permit persons to whom
+  ~ the Software is  furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included
+  ~ in all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+  ~ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+  ~ OR OTHER DEALINGS IN THE SOFTWARE.
+  -->
+
 <test-data
     xmlns="http://pmd.sourceforge.net/rule-tests"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/src/test/resources/io/github/dgroup/arch4u/pmd/xml/NoMandatoryConstructorInExceptionClass.xml
+++ b/src/test/resources/io/github/dgroup/arch4u/pmd/xml/NoMandatoryConstructorInExceptionClass.xml
@@ -46,7 +46,7 @@ class MyException extends Exception {
 
   <test-code>
     <description>
-      [GOOD]: mandatory constructor MyException(String, Object...) is provided
+      [GOOD]: mandatory constructor `MyException(String, Object...)` is provided
     </description>
     <expected-problems>0</expected-problems>
     <code><![CDATA[
@@ -60,7 +60,7 @@ class MyException extends Exception {
 
   <test-code>
     <description>
-      [GOOD]: mandatory constructor MyException(Throwable, String, Object...) is provided
+      [GOOD]: mandatory constructor `MyException(Throwable, String, Object...)` is provided
     </description>
     <expected-problems>0</expected-problems>
     <code><![CDATA[
@@ -68,6 +68,30 @@ class MyException extends Exception {
     public MyException(Throwable cause, String pattern, Object... args) {
          super(String.format(pattern, args));
    }
+}
+    ]]></code>
+  </test-code>
+
+  <test-code>
+    <description>
+      [GOOD]: exception with mandatory constructor extends ArithmeticException
+    </description>
+    <expected-problems>0</expected-problems>
+    <code><![CDATA[
+class MyException extends ArithmeticException {
+    public MyException(Throwable cause, String pattern, Object... args) {}
+}
+    ]]></code>
+  </test-code>
+
+  <test-code>
+    <description>[GOOD]: inner exception class with mandatory constructor</description>
+    <expected-problems>0</expected-problems>
+    <code><![CDATA[
+class Foo {
+    private class InnerException extends Exception {
+        public InnerException(String pattern, Object... args) {}
+    }
 }
     ]]></code>
   </test-code>
@@ -83,7 +107,7 @@ class MyException extends Exception {                       //violation
   </test-code>
 
   <test-code>
-    <description>[BAD]: no mandatory constructor</description>
+    <description>[BAD]: no mandatory constructor: public MyException()</description>
     <expected-problems>1</expected-problems>
     <expected-linenumbers>1</expected-linenumbers>
     <code><![CDATA[
@@ -95,7 +119,7 @@ class MyException extends Exception {                       //violation
   </test-code>
 
   <test-code>
-    <description>[BAD]: no mandatory constructor</description>
+    <description>[BAD]: no mandatory constructor: public MyException(Throwable, Object...)</description>
     <expected-problems>1</expected-problems>
     <expected-linenumbers>1</expected-linenumbers>
     <code><![CDATA[
@@ -130,4 +154,27 @@ class MyException extends Exception {                       //violation
     ]]></code>
   </test-code>
 
+  <test-code>
+    <description>[BAD]: constructor has non-public modifier</description>
+    <expected-problems>1</expected-problems>
+    <expected-linenumbers>1</expected-linenumbers>
+    <code><![CDATA[
+class MyException extends Exception {                       //violation
+    MyException(Exception cause, String pattern, Object... args) {}
+}
+    ]]></code>
+  </test-code>
+
+  <test-code>
+    <description>[BAD]: inner exception class without mandatory constructor</description>
+    <expected-problems>1</expected-problems>
+    <expected-linenumbers>2</expected-linenumbers>
+    <code><![CDATA[
+class Foo {
+    private class InnerException extends Exception {              //violation
+        public InnerException(Object pattern, Object... args) {}
+    }
+}
+    ]]></code>
+  </test-code>
 </test-data>

--- a/src/test/resources/io/github/dgroup/arch4u/pmd/xml/NoMandatoryConstructorInExceptionClass.xml
+++ b/src/test/resources/io/github/dgroup/arch4u/pmd/xml/NoMandatoryConstructorInExceptionClass.xml
@@ -160,7 +160,7 @@ class MyException extends Exception {                       //violation
     <expected-linenumbers>1</expected-linenumbers>
     <code><![CDATA[
 class MyException extends Exception {                       //violation
-    MyException(Exception cause, String pattern, Object... args) {}
+    MyException(Throwable cause, String pattern, Object... args) {}
 }
     ]]></code>
   </test-code>

--- a/src/test/resources/io/github/dgroup/arch4u/pmd/xml/NoMandatoryConstructorInExceptionClass.xml
+++ b/src/test/resources/io/github/dgroup/arch4u/pmd/xml/NoMandatoryConstructorInExceptionClass.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ MIT License
+  ~
+  ~ Copyright (c) 2019-2022 Yurii Dubinka
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"),
+  ~ to deal in the Software without restriction, including without limitation
+  ~ the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  ~ and/or sell copies of the Software, and to permit persons to whom
+  ~ the Software is  furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included
+  ~ in all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+  ~ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+  ~ OR OTHER DEALINGS IN THE SOFTWARE.
+  -->
+
+<test-data
+    xmlns="http://pmd.sourceforge.net/rule-tests"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests https://pmd.sourceforge.io/rule-tests_1_0_0.xsd">
+
+  <test-code>
+    <description>[GOOD]: all mandatory constructors are provided</description>
+    <expected-problems>0</expected-problems>
+    <code><![CDATA[
+class MyException extends Exception {
+    public MyException(String pattern, Object... args) {
+         super(String.format(pattern, args));
+   }
+
+   public MyException(Throwable cause, String pattern, Object... args) {
+         super(String.format(pattern, args), cause);
+   }
+}
+    ]]></code>
+  </test-code>
+
+  <test-code>
+    <description>
+      [GOOD]: mandatory constructor MyException(String, Object...) is provided
+    </description>
+    <expected-problems>0</expected-problems>
+    <code><![CDATA[
+class MyException extends Exception {
+    public MyException(String pattern, Object... args) {
+         super(String.format(pattern, args));
+   }
+}
+    ]]></code>
+  </test-code>
+
+  <test-code>
+    <description>
+      [GOOD]: mandatory constructor MyException(Throwable, String, Object...) is provided
+    </description>
+    <expected-problems>0</expected-problems>
+    <code><![CDATA[
+class MyException extends Exception {
+    public MyException(Throwable cause, String pattern, Object... args) {
+         super(String.format(pattern, args));
+   }
+}
+    ]]></code>
+  </test-code>
+
+  <test-code>
+    <description>[BAD]: no constructors</description>
+    <expected-problems>1</expected-problems>
+    <expected-linenumbers>1</expected-linenumbers>
+    <code><![CDATA[
+class MyException extends Exception {                       //violation
+}
+    ]]></code>
+  </test-code>
+
+  <test-code>
+    <description>[BAD]: no mandatory constructor</description>
+    <expected-problems>1</expected-problems>
+    <expected-linenumbers>1</expected-linenumbers>
+    <code><![CDATA[
+class MyException extends Exception {                       //violation
+    public MyException() {
+    }
+}
+    ]]></code>
+  </test-code>
+
+  <test-code>
+    <description>[BAD]: no mandatory constructor</description>
+    <expected-problems>1</expected-problems>
+    <expected-linenumbers>1</expected-linenumbers>
+    <code><![CDATA[
+class MyException extends Exception {                       //violation
+    public MyException(Throwable cause, Object... args) {
+    }
+}
+    ]]></code>
+  </test-code>
+
+  <test-code>
+    <description>[BAD]: no mandatory constructor</description>
+    <expected-problems>1</expected-problems>
+    <expected-linenumbers>1</expected-linenumbers>
+    <code><![CDATA[
+class MyException extends Exception {                       //violation
+    public MyException(String pattern, Integer... args) {
+    }
+}
+    ]]></code>
+  </test-code>
+
+  <test-code>
+    <description>[BAD]: no mandatory constructor</description>
+    <expected-problems>1</expected-problems>
+    <expected-linenumbers>1</expected-linenumbers>
+    <code><![CDATA[
+class MyException extends Exception {                       //violation
+    public MyException(Exception cause, String pattern, Object... args) {
+    }
+}
+    ]]></code>
+  </test-code>
+
+</test-data>


### PR DESCRIPTION
# Description
A new rule has been implemented to check if an exception class has constructors with required signature:
`public Ctor(Throwable, String, Object...)` or `public Ctor(String, Object...)`
```java
class MyException extends Exception {
    public MyException(String pattern, Object... args) {}

    public MyException(Throwable cause, String pattern, Object... args) {}
}
```

# Completed work
- [x] Added new rule
- [x] Added new unit tests
- [x] Passed all checks

# Related issues: 
Implements #3 