### PR TITLE
New rule to prohibit usage list of classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
   <groupId>io.github.dgroup</groupId>
   <artifactId>arch4u-pmd</artifactId>
   <!-- @todo #/DEV Write minimalistic/laconic project overview in readme.md -->
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <!-- @todo #/DEV Setup code code quality 3rd-party services and add badge to the readme.md -->
   <packaging>jar</packaging>
   <name>${project.artifactId}</name>

--- a/src/main/resources/io/github/dgroup/arch4u/pmd/test-ruleset.xml
+++ b/src/main/resources/io/github/dgroup/arch4u/pmd/test-ruleset.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0"?>
+
+<ruleset name="Test"
+         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
+         xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
+
+  <description>Test ruleset</description>
+
+  <rule name="DontUseProhibitedClasses"
+        since="0.3.0"
+        language="java"
+        message="The {0} class is prohibited to use."
+        class="net.sourceforge.pmd.lang.rule.XPathRule">
+    <description>
+      Don't use prohibited classes.
+      See discussion about implementation on Github: https://github.com/pmd/pmd/discussions/3705
+    </description>
+    <priority>3</priority>
+    <properties>
+      <property name="fullName" type="List[String]" delimiter="|"
+                description="Full name of prohibited classes"
+                value="org.apache.commons.codec.CharEncoding
+|org.apache.commons.lang3.CharEncoding
+|org.apache.commons.lang.CharEncoding
+|org.apache.log4j.Logger"/>
+      <property name="shortName" type="List[String]" delimiter="|"
+                description="Short name of prohibited classes"
+                value="CharEncoding|Logger"/>
+      <property name="version" value="2.0"/>
+      <property name="xpath">
+        <value>
+<![CDATA[
+(: check type :)
+//Name
+[not(parent::ImportDeclaration)]
+[some $class in $fullName satisfies pmd-java:typeIsExactly($class)]
+|
+//ClassOrInterfaceType
+[some $class in $fullName satisfies pmd-java:typeIsExactly($class)]
+|
+(: import + usage :)
+//Name
+[
+    //ImportDeclaration/Name
+    [some $class in $fullName satisfies starts-with(@Image, $class)]
+]
+[some $class in $shortName satisfies starts-with(@Image, $class)]
+|
+(: FQN usage :)
+//Name
+[not(parent::ImportDeclaration)]
+[some $class in $fullName satisfies starts-with(@Image, $class)]
+|
+(: static import + usage :)
+//Name
+[not(parent::ImportDeclaration)]
+[
+  (: bind the context node to a variable :)
+  some $name in (.) satisfies
+  //ImportDeclaration[@Static = true()]
+    /Name
+    [some $class in $fullName satisfies starts-with(@Image, $class)]
+    [ends-with(@Image, $name/@Image)]
+]
+]]>
+        </value>
+      </property>
+    </properties>
+    <example>
+<![CDATA[
+import org.apache.log4j.Logger;
+import java.nio.charset.Charset;
+import org.apache.commons.codec.CharEncoding;
+class Foo {
+    private static Logger log = Logger.getLogger(Foo.class);
+    Charset cs = Charset.forName(CharEncoding.UTF_8);
+}
+]]>
+    </example>
+  </rule>
+</ruleset>

--- a/src/test/java/io/github/dgroup/arch4u/pmd/DontUseProhibitedClassesTest.java
+++ b/src/test/java/io/github/dgroup/arch4u/pmd/DontUseProhibitedClassesTest.java
@@ -1,0 +1,44 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019-2022 Yurii Dubinka
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom
+ * the Software is  furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ * OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.dgroup.arch4u.pmd;
+
+import net.sourceforge.pmd.testframework.SimpleAggregatorTst;
+
+/**
+ * Test case for {@code DontUseProhibitedClasses} rule.
+ *
+ * @since 0.3.0
+ */
+@SuppressWarnings({"PMD.TestClassWithoutTestCases", "PMD.JUnit4TestShouldUseBeforeAnnotation"})
+public final class DontUseProhibitedClassesTest extends SimpleAggregatorTst {
+
+    @Override
+    public void setUp() {
+        addRule(
+            "io/github/dgroup/arch4u/pmd/test-ruleset.xml",
+            "DontUseProhibitedClasses"
+        );
+    }
+}

--- a/src/test/resources/io/github/dgroup/arch4u/pmd/xml/DontUseProhibitedClasses.xml
+++ b/src/test/resources/io/github/dgroup/arch4u/pmd/xml/DontUseProhibitedClasses.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ MIT License
+  ~
+  ~ Copyright (c) 2019-2022 Yurii Dubinka
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"),
+  ~ to deal in the Software without restriction, including without limitation
+  ~ the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  ~ and/or sell copies of the Software, and to permit persons to whom
+  ~ the Software is  furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included
+  ~ in all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+  ~ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+  ~ OR OTHER DEALINGS IN THE SOFTWARE.
+  -->
+
+<test-data
+    xmlns="http://pmd.sourceforge.net/rule-tests"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests https://pmd.sourceforge.io/rule-tests_1_0_0.xsd">
+
+  <test-code>
+    <description>[BAD]: prohibited class org.apache.commons.codec.CharEncoding is used</description>
+    <rule-property name="fullName">org.apache.commons.codec.CharEncoding</rule-property>
+    <rule-property name="shortName">CharEncoding</rule-property>
+    <expected-problems>1</expected-problems>
+    <expected-messages>
+      <message>The CharEncoding.UTF_8 class is prohibited to use.</message>
+    </expected-messages>
+    <code><![CDATA[
+import java.nio.charset.Charset;
+import org.apache.commons.codec.CharEncoding;
+class Foo {
+    Charset cs = Charset.forName(CharEncoding.UTF_8);
+}
+        ]]></code>
+  </test-code>
+
+  <test-code>
+    <description>[BAD]: prohibited class org.apache.log4j.Logger is used</description>
+    <rule-property name="fullName">org.apache.log4j.Logger</rule-property>
+    <rule-property name="shortName">Logger</rule-property>
+    <expected-problems>2</expected-problems>
+    <expected-linenumbers>3, 3</expected-linenumbers>
+    <expected-messages>
+      <message>The Logger class is prohibited to use.</message>
+      <message>The Logger.getLogger class is prohibited to use.</message>
+    </expected-messages>
+    <code><![CDATA[
+import org.apache.log4j.Logger;
+class Foo {
+    private static Logger log = Logger.getLogger(LogClass.class);
+
+    void bar() {
+        log.trace("Trace Message!");
+    }
+}
+        ]]></code>
+  </test-code>
+
+  <test-code>
+    <description>[BAD]: prohibited class org.apache.commons.codec.CharEncoding is used</description>
+    <rule-property name="fullName">org.apache.commons.codec.CharEncoding|org.apache.log4j.Logger</rule-property>
+    <rule-property name="shortName">CharEncoding|Logger</rule-property>
+    <expected-problems>2</expected-problems>
+    <expected-messages>
+      <message>The CharEncoding class is prohibited to use.</message>
+      <message>The org.apache.log4j.Logger class is prohibited to use.</message>
+    </expected-messages>
+    <code><![CDATA[
+import org.apache.commons.codec.CharEncoding;
+class Foo {
+    void bar(CharEncoding ce) {
+    }
+
+    void bar(org.apache.log4j.Logger log) {
+    }
+}
+        ]]></code>
+  </test-code>
+
+</test-data>


### PR DESCRIPTION
# Description
The rule is conteined in the new `test-ruleset.xml` ruleset.
A new rule has been implemented to check if an prohibited class is used.
Default prohibited classes are:
- org.apache.commons.codec.CharEncoding
- org.apache.commons.lang3.CharEncoding
- org.apache.commons.lang.CharEncoding
- org.apache.log4j.Logger

```java
import org.apache.log4j.Logger;
import java.nio.charset.Charset;
import org.apache.commons.codec.CharEncoding;
class Foo {
    private static Logger log = Logger.getLogger(Foo.class); //violation
    Charset cs = Charset.forName(CharEncoding.UTF_8);       //violation
}
```

# Completed work
- [x] Added new rule
- [x] Added new unit tests
- [x] Passed all checks

# Related issues: 
Implements #21  