### PR TITLE
Upgrade pmd-java/pmd-test dependencies from 7.8.0 to 7.25.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
     <sonar.version>3.4.0.905</sonar.version>
     <commons-logging.version>1.2</commons-logging.version>
     <!-- General dependencies -->
-    <pmd.rules.version>7.8.0</pmd.rules.version>
+    <pmd.rules.version>7.25.0</pmd.rules.version>
     <!-- Testing -->
     <hamcrest.version>2.2</hamcrest.version>
     <cactoos-matchers.version>0.25</cactoos-matchers.version>

--- a/readme.md
+++ b/readme.md
@@ -31,8 +31,8 @@ REST API, logging, monitoring, etc., including reconfigured default pmd
 rules to decrease false-positive
 violations during usage of well-known frameworks like Spring, Quarkus, etc.
 
-In addition to our custom/reconfigured rules we are using the latest stable pmd-java version which is `7.6.0` with more
-than [320+ rules](https://docs.pmd-code.org/pmd-doc-7.6.0/pmd_rules_java.html) with default configuration.
+In addition to our custom/reconfigured rules we are using the latest stable pmd-java version which is `7.25.0` with more
+than [320+ rules](https://docs.pmd-code.org/pmd-doc-7.25.0/pmd_rules_java.html) with default configuration.
 
 Legend:
 
@@ -51,25 +51,25 @@ Legend:
 | [AvoidUsingObjectMapperAsALocalVariable](https://github.com/dgroup/arch4u-pmd/discussions/30)                                             | `arch4u-pmd:0.1.0` |   ✅    |   ✅    |    ⌛    |
 | [AvoidMdcOutsideTryStatement](https://github.com/dgroup/arch4u-pmd/discussions/86)                                                        | `arch4u-pmd:0.1.0` |   ✅    |   ✅    |    ⌛    |
 | [PotentiallyThreadLocalPollutionByMdc](https://github.com/dgroup/arch4u-pmd/discussions/88)                                               | `arch4u-pmd:0.1.0` |   ✅    |   ✅    |    ⌛    |
-| [GuardLogStatement](https://pmd.github.io/latest/pmd_rules_java_bestpractices.html#guardlogstatement)                                     | `pmd-java:7.6.0`  |   ❌    |   ❌    |    ❌    |
-| [JUnitAssertionsShouldIncludeMessage](https://pmd.github.io/latest/pmd_rules_java_bestpractices.html#junitassertionsshouldincludemessage) | `pmd-java:7.6.0`  |   🌵   |   ⌛    |    ⌛    |
-| [UnusedPrivateMethod](https://pmd.github.io/latest/pmd_rules_java_bestpractices.html#unusedprivatemethod)                                 | `pmd-java:7.6.0`  |   🌵   |   ⌛    |    ⌛    |
-| [AtLeastOneConstructor](https://pmd.github.io/latest/pmd_rules_java_codestyle.html#atleastoneconstructor)                                 | `pmd-java:7.6.0`  |   🌵   |   ✅    |    ⌛    |
-| [OnlyOneReturn](https://pmd.github.io/latest/pmd_rules_java_codestyle.html#onlyonereturn)                                                 | `pmd-java:7.6.0`  |   🌵   |   ⌛    |    ⌛    |
-| [CommentRequired](https://pmd.github.io/latest/pmd_rules_java_documentation.html#commentrequired)                                         | `pmd-java:7.6.0`  |   🌵   |   ⌛    |    ⌛    |
-| [AvoidCatchingGenericException](https://pmd.github.io/latest/pmd_rules_java_design.html#avoidcatchinggenericexception)                    | `pmd-java:7.6.0`  |   ⌛    |   ⌛    |    ⌛    |
-| [CouplingBetweenObjects](https://pmd.github.io/latest/pmd_rules_java_design.html#couplingbetweenobjects)                                  | `pmd-java:7.6.0`  |   🌵   |   ⌛    |    ⌛    |
-| [LawOfDemeter](https://pmd.github.io/latest/pmd_rules_java_design.html#lawofdemeter)                                                      | `pmd-java:7.6.0`  |   ❌    |   ❌    |    ❌    |
-| [LoosePackageCoupling](https://pmd.github.io/latest/pmd_rules_java_design.html#loosepackagecoupling)                                      | `pmd-java:7.6.0`  |   ⌛    |   ⌛    |    ⌛    |
-| [SignatureDeclareThrowsException](https://pmd.github.io/latest/pmd_rules_java_design.html#signaturedeclarethrowsexception)                | `pmd-java:7.6.0`  |   ⌛    |   ⌛    |    ⌛    |
-| [TooManyFields](https://pmd.github.io/latest/pmd_rules_java_design.html#toomanyfields)                                                    | `pmd-java:7.6.0`  |   🌵   |   ⌛    |    ⌛    |
-| [TooManyMethods](https://pmd.github.io/latest/pmd_rules_java_design.html#toomanymethods)                                                  | `pmd-java:7.6.0`  |   🌵   |   ⌛    |    ⌛    |
-| [UseObjectForClearerAPI](https://pmd.github.io/latest/pmd_rules_java_design.html#useobjectforclearerapi)                                  | `pmd-java:7.6.0`  |   ❌    |   ❌    |    ❌    |
-| [AtLeastOneConstructor](https://pmd.github.io/latest/pmd_rules_java_codestyle.html#atleastoneconstructor)                                 | `pmd-java:7.6.0`  |   ❌    |   ❌    |    ❌    |
-| [UseUtilityClass](https://pmd.github.io/latest/pmd_rules_java_design.html#useutilityclass)                                                | `pmd-java:7.6.0`  |   🌵   |   ✅    |    ⌛    |
-| [ShortClassName](https://pmd.github.io/latest/pmd_rules_java_codestyle.html#shortclassname)                                               | `pmd-java:7.6.0`  |   🌵   |   ✅    |    ✅    |
-| [ImmutableField](https://pmd.github.io/latest/pmd_rules_java_design.html#immutablefield)                                                  | `pmd-java:7.6.0`  |   🌵   |   ✅    |    ✅    |
-| [LongVariable](https://pmd.github.io/latest/pmd_rules_java_codestyle.html#longvariable)                                                   | `pmd-java:7.6.0`  |   🌵   |   ✅    |    ✅    |
+| [GuardLogStatement](https://pmd.github.io/latest/pmd_rules_java_bestpractices.html#guardlogstatement)                                     | `pmd-java:7.25.0`  |   ❌    |   ❌    |    ❌    |
+| [JUnitAssertionsShouldIncludeMessage](https://pmd.github.io/latest/pmd_rules_java_bestpractices.html#junitassertionsshouldincludemessage) | `pmd-java:7.25.0`  |   🌵   |   ⌛    |    ⌛    |
+| [UnusedPrivateMethod](https://pmd.github.io/latest/pmd_rules_java_bestpractices.html#unusedprivatemethod)                                 | `pmd-java:7.25.0`  |   🌵   |   ⌛    |    ⌛    |
+| [AtLeastOneConstructor](https://pmd.github.io/latest/pmd_rules_java_codestyle.html#atleastoneconstructor)                                 | `pmd-java:7.25.0`  |   🌵   |   ✅    |    ⌛    |
+| [OnlyOneReturn](https://pmd.github.io/latest/pmd_rules_java_codestyle.html#onlyonereturn)                                                 | `pmd-java:7.25.0`  |   🌵   |   ⌛    |    ⌛    |
+| [CommentRequired](https://pmd.github.io/latest/pmd_rules_java_documentation.html#commentrequired)                                         | `pmd-java:7.25.0`  |   🌵   |   ⌛    |    ⌛    |
+| [AvoidCatchingGenericException](https://pmd.github.io/latest/pmd_rules_java_design.html#avoidcatchinggenericexception)                    | `pmd-java:7.25.0`  |   ⌛    |   ⌛    |    ⌛    |
+| [CouplingBetweenObjects](https://pmd.github.io/latest/pmd_rules_java_design.html#couplingbetweenobjects)                                  | `pmd-java:7.25.0`  |   🌵   |   ⌛    |    ⌛    |
+| [LawOfDemeter](https://pmd.github.io/latest/pmd_rules_java_design.html#lawofdemeter)                                                      | `pmd-java:7.25.0`  |   ❌    |   ❌    |    ❌    |
+| [LoosePackageCoupling](https://pmd.github.io/latest/pmd_rules_java_design.html#loosepackagecoupling)                                      | `pmd-java:7.25.0`  |   ⌛    |   ⌛    |    ⌛    |
+| [SignatureDeclareThrowsException](https://pmd.github.io/latest/pmd_rules_java_design.html#signaturedeclarethrowsexception)                | `pmd-java:7.25.0`  |   ⌛    |   ⌛    |    ⌛    |
+| [TooManyFields](https://pmd.github.io/latest/pmd_rules_java_design.html#toomanyfields)                                                    | `pmd-java:7.25.0`  |   🌵   |   ⌛    |    ⌛    |
+| [TooManyMethods](https://pmd.github.io/latest/pmd_rules_java_design.html#toomanymethods)                                                  | `pmd-java:7.25.0`  |   🌵   |   ⌛    |    ⌛    |
+| [UseObjectForClearerAPI](https://pmd.github.io/latest/pmd_rules_java_design.html#useobjectforclearerapi)                                  | `pmd-java:7.25.0`  |   ❌    |   ❌    |    ❌    |
+| [AtLeastOneConstructor](https://pmd.github.io/latest/pmd_rules_java_codestyle.html#atleastoneconstructor)                                 | `pmd-java:7.25.0`  |   ❌    |   ❌    |    ❌    |
+| [UseUtilityClass](https://pmd.github.io/latest/pmd_rules_java_design.html#useutilityclass)                                                | `pmd-java:7.25.0`  |   🌵   |   ✅    |    ⌛    |
+| [ShortClassName](https://pmd.github.io/latest/pmd_rules_java_codestyle.html#shortclassname)                                               | `pmd-java:7.25.0`  |   🌵   |   ✅    |    ✅    |
+| [ImmutableField](https://pmd.github.io/latest/pmd_rules_java_design.html#immutablefield)                                                  | `pmd-java:7.25.0`  |   🌵   |   ✅    |    ✅    |
+| [LongVariable](https://pmd.github.io/latest/pmd_rules_java_codestyle.html#longvariable)                                                   | `pmd-java:7.25.0`  |   🌵   |   ✅    |    ✅    |
 
 ### How to use?
 


### PR DESCRIPTION
## Summary

Upgrades the PMD dependencies to the latest stable release.

- Bumps `pmd.rules.version` (which drives both `net.sourceforge.pmd:pmd-java` and `net.sourceforge.pmd:pmd-test`) from **7.8.0** to **7.25.0** — the latest stable release on Maven Central.
- Updates the stale `pmd-java:7.6.0` references in `readme.md` (the rule provider table and the "latest stable pmd-java version" line and doc link) to **7.25.0**.

## Verification

- `mvn clean test` → all **81 tests pass** with PMD 7.25.0 (no API breakage).
- `mvn -B -Pqulice clean install` (the exact CI command) → **BUILD SUCCESS**, including qulice static analysis and JaCoCo coverage gates.

https://claude.ai/code/session_012p4bAJd2Ck8Zic6jUuch1y

---
_Generated by [Claude Code](https://claude.ai/code/session_012p4bAJd2Ck8Zic6jUuch1y)_