### PR TITLE
New rule: AvoidMixingJunit4AndJunit5 (#147)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -51,6 +51,7 @@ Legend:
 | [AvoidUsingObjectMapperAsALocalVariable](https://github.com/dgroup/arch4u-pmd/discussions/30)                                             | `arch4u-pmd:0.1.0` |   ✅    |   ✅    |    ⌛    |
 | [AvoidMdcOutsideTryStatement](https://github.com/dgroup/arch4u-pmd/discussions/86)                                                        | `arch4u-pmd:0.1.0` |   ✅    |   ✅    |    ⌛    |
 | [PotentiallyThreadLocalPollutionByMdc](https://github.com/dgroup/arch4u-pmd/discussions/88)                                               | `arch4u-pmd:0.1.0` |   ✅    |   ✅    |    ⌛    |
+| [AvoidMixingJunit4AndJunit5](https://github.com/dgroup/arch4u-pmd/issues/147)                                                             | `arch4u-pmd:0.1.0` |   ✅    |   ✅    |    ✅    |
 | [GuardLogStatement](https://pmd.github.io/latest/pmd_rules_java_bestpractices.html#guardlogstatement)                                     | `pmd-java:7.25.0`  |   ❌    |   ❌    |    ❌    |
 | [JUnitAssertionsShouldIncludeMessage](https://pmd.github.io/latest/pmd_rules_java_bestpractices.html#junitassertionsshouldincludemessage) | `pmd-java:7.25.0`  |   🌵   |   ⌛    |    ⌛    |
 | [UnusedPrivateMethod](https://pmd.github.io/latest/pmd_rules_java_bestpractices.html#unusedprivatemethod)                                 | `pmd-java:7.25.0`  |   🌵   |   ⌛    |    ⌛    |

--- a/src/main/resources/io/github/dgroup/arch4u/pmd/arch4u-ruleset.xml
+++ b/src/main/resources/io/github/dgroup/arch4u/pmd/arch4u-ruleset.xml
@@ -349,6 +349,10 @@
   </rule>
 
 
+  <!-- Rules related to testing -->
+  <rule ref="io/github/dgroup/arch4u/pmd/testing/junit.xml"/>
+
+
   <!-- Third-party rules -->
     <rule ref="category/java/bestpractices.xml">
       <exclude name="GuardLogStatement"/> <!-- @todo #/DEV GuardLogStatement: deep investigation is needed regarding purpose and goal of this this rule. Potentially improvement is needed. -->

--- a/src/main/resources/io/github/dgroup/arch4u/pmd/testing/junit.xml
+++ b/src/main/resources/io/github/dgroup/arch4u/pmd/testing/junit.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0"?>
+<!--
+  ~ MIT License
+  ~
+  ~ Copyright (c) 2019-2024 Yurii Dubinka
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"),
+  ~ to deal in the Software without restriction, including without limitation
+  ~ the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  ~ and/or sell copies of the Software, and to permit persons to whom
+  ~ the Software is  furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included
+  ~ in all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+  ~ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+  ~ OR OTHER DEALINGS IN THE SOFTWARE.
+  -->
+
+<ruleset name="arch4u-junit"
+         xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
+
+  <description>Rules related to JUnit testing framework.</description>
+
+  <!-- Rules related to JUnit -->
+  <rule name="AvoidMixingJunit4AndJunit5"
+        since="0.1.0"
+        language="java"
+        externalInfoUrl="https://github.com/dgroup/arch4u-pmd/issues/147"
+        message="Avoid mixing JUnit 4 and JUnit 5 within the same test class: https://github.com/dgroup/arch4u-pmd/issues/147"
+        class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
+    <description>
+      A test class should rely on a single JUnit version. Mixing JUnit 4 (org.junit.*)
+      and JUnit 5 (org.junit.jupiter.*) annotations or imports in the same class is error-prone:
+      depending on the configured test engine, some of the test methods (or the whole lifecycle
+      callbacks such as @Before/@BeforeEach) are silently ignored and never executed.
+      Read more: https://github.com/dgroup/arch4u-pmd/issues/147
+    </description>
+    <priority>3</priority>
+    <properties>
+      <property name="xpath">
+        <value>
+          <![CDATA[
+//ClassDeclaration[@TopLevel = true()]
+[
+    (: A JUnit 5 (org.junit.jupiter.*) reference is present :)
+    (
+        ../ImportDeclaration[starts-with(@PackageName, 'org.junit.jupiter')]
+        or
+        .//ClassType[@FullyQualified = true() and starts-with(@PackageQualifier, 'org.junit.jupiter')]
+    )
+    and
+    (: A JUnit 4 (org.junit.* but not org.junit.jupiter.*) reference is present :)
+    (
+        ../ImportDeclaration[
+            (@PackageName = 'org.junit' or starts-with(@PackageName, 'org.junit.'))
+            and not(starts-with(@PackageName, 'org.junit.jupiter'))
+        ]
+        or
+        .//ClassType[
+            @FullyQualified = true()
+            and (@PackageQualifier = 'org.junit' or starts-with(@PackageQualifier, 'org.junit.'))
+            and not(starts-with(@PackageQualifier, 'org.junit.jupiter'))
+        ]
+    )
+]
+          ]]>
+        </value>
+      </property>
+    </properties>
+    <example>
+      <![CDATA[
+      import org.junit.jupiter.api.extension.ExtendWith;
+
+      @ExtendWith(Xxx.class)         // JUnit 5
+      class MyTest {                 // violation: the class mixes JUnit 4 and JUnit 5
+
+          @org.junit.Test            // JUnit 4, silently ignored by the JUnit 5 engine
+          public void justTestIt() {
+              // ...
+          }
+      }
+      ]]>
+    </example>
+  </rule>
+
+</ruleset>

--- a/src/test/java/io/github/dgroup/arch4u/pmd/AvoidMixingJunit4AndJunit5Test.java
+++ b/src/test/java/io/github/dgroup/arch4u/pmd/AvoidMixingJunit4AndJunit5Test.java
@@ -1,0 +1,44 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019-2024 Yurii Dubinka
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom
+ * the Software is  furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ * OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.dgroup.arch4u.pmd;
+
+import net.sourceforge.pmd.test.SimpleAggregatorTst;
+
+/**
+ * Test case for {@code AvoidMixingJunit4AndJunit5} rule.
+ *
+ * @since 0.1.0
+ */
+@SuppressWarnings({"PMD.TestClassWithoutTestCases", "PMD.JUnit4TestShouldUseBeforeAnnotation"})
+public final class AvoidMixingJunit4AndJunit5Test extends SimpleAggregatorTst {
+
+    @Override
+    public void setUp() {
+        addRule(
+            "io/github/dgroup/arch4u/pmd/testing/junit.xml",
+            "AvoidMixingJunit4AndJunit5"
+        );
+    }
+}

--- a/src/test/resources/io/github/dgroup/arch4u/pmd/xml/AvoidMixingJunit4AndJunit5.xml
+++ b/src/test/resources/io/github/dgroup/arch4u/pmd/xml/AvoidMixingJunit4AndJunit5.xml
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ MIT License
+  ~
+  ~ Copyright (c) 2019-2024 Yurii Dubinka
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"),
+  ~ to deal in the Software without restriction, including without limitation
+  ~ the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  ~ and/or sell copies of the Software, and to permit persons to whom
+  ~ the Software is  furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included
+  ~ in all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+  ~ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+  ~ OR OTHER DEALINGS IN THE SOFTWARE.
+  -->
+
+<test-data
+  xmlns="http://pmd.sourceforge.net/rule-tests"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests https://pmd.sourceforge.io/rule-tests_1_0_0.xsd">
+
+  <test-code>
+    <description>[GOOD]: pure JUnit 5 test class</description>
+    <expected-problems>0</expected-problems>
+    <code><![CDATA[
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+
+class MyTest {
+    @BeforeEach
+    void init() {}
+
+    @Test
+    void justTestIt() {}
+}
+    ]]></code>
+  </test-code>
+
+  <test-code>
+    <description>[GOOD]: pure JUnit 4 test class</description>
+    <expected-problems>0</expected-problems>
+    <code><![CDATA[
+import org.junit.Before;
+import org.junit.Test;
+
+class MyTest {
+    @Before
+    public void init() {}
+
+    @Test
+    public void justTestIt() {}
+}
+    ]]></code>
+  </test-code>
+
+  <test-code>
+    <description>[GOOD]: pure JUnit 4 test class with runner</description>
+    <expected-problems>0</expected-problems>
+    <code><![CDATA[
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+class MyTest {
+    @Test
+    public void justTestIt() {}
+}
+    ]]></code>
+  </test-code>
+
+  <test-code>
+    <description>[GOOD]: class without any JUnit usage</description>
+    <expected-problems>0</expected-problems>
+    <code><![CDATA[
+import java.util.List;
+
+class MyTest {
+    public void justTestIt() {}
+}
+    ]]></code>
+  </test-code>
+
+  <test-code>
+    <description>[GOOD]: pure JUnit 5 test class with fully-qualified annotations</description>
+    <expected-problems>0</expected-problems>
+    <code><![CDATA[
+@org.junit.jupiter.api.extension.ExtendWith(Xxx.class)
+class MyTest {
+    @org.junit.jupiter.api.Test
+    void justTestIt() {}
+}
+    ]]></code>
+  </test-code>
+
+  <test-code>
+    <description>[BAD]: imports both JUnit 4 and JUnit 5</description>
+    <expected-problems>1</expected-problems>
+    <expected-linenumbers>4</expected-linenumbers>
+    <code><![CDATA[
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.Test;
+
+class MyTest {                            //violation
+    @BeforeEach
+    void init() {}
+
+    @Test
+    public void justTestIt() {}
+}
+    ]]></code>
+  </test-code>
+
+  <test-code>
+    <description>[BAD]: JUnit 5 import mixed with fully-qualified JUnit 4 annotation</description>
+    <expected-problems>1</expected-problems>
+    <expected-linenumbers>4</expected-linenumbers>
+    <code><![CDATA[
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(Xxx.class)
+class MyTest {                            //violation
+    @org.junit.Test
+    public void justTestIt() {}
+}
+    ]]></code>
+  </test-code>
+
+  <test-code>
+    <description>[BAD]: fully-qualified JUnit 4 and JUnit 5 annotations without imports</description>
+    <expected-problems>1</expected-problems>
+    <expected-linenumbers>2</expected-linenumbers>
+    <code><![CDATA[
+@org.junit.jupiter.api.extension.ExtendWith(Xxx.class)
+class MyTest {                            //violation
+    @org.junit.Test
+    public void justTestIt() {}
+}
+    ]]></code>
+  </test-code>
+
+  <test-code>
+    <description>[BAD]: JUnit 4 runner mixed with JUnit 5 lifecycle annotation</description>
+    <expected-problems>1</expected-problems>
+    <expected-linenumbers>6</expected-linenumbers>
+    <code><![CDATA[
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.BeforeEach;
+
+@RunWith(JUnit4.class)
+class MyTest {                            //violation
+    @BeforeEach
+    void init() {}
+}
+    ]]></code>
+  </test-code>
+
+  <test-code>
+    <description>[BAD]: static imports of JUnit 4 and JUnit 5 assertions</description>
+    <expected-problems>1</expected-problems>
+    <expected-linenumbers>5</expected-linenumbers>
+    <code><![CDATA[
+import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+
+class MyTest {                            //violation
+    @Test
+    void justTestIt() {
+        assertEquals(1, 1);
+        assertTrue(true);
+    }
+}
+    ]]></code>
+  </test-code>
+
+</test-data>


### PR DESCRIPTION
## Summary

Implements issue #147 — a new PMD rule **`AvoidMixingJunit4AndJunit5`** (category: Error Prone) that flags a test class mixing JUnit 4 (`org.junit.*`) and JUnit 5 (`org.junit.jupiter.*`) in the same class.

Mixing the two is error-prone: depending on the configured test engine, some test methods or lifecycle callbacks (e.g. `@Before` vs `@BeforeEach`) are silently ignored and never executed.

## What's included

- **New ruleset** `src/main/resources/io/github/dgroup/arch4u/pmd/testing/junit.xml` containing the XPath-based rule.
- Rule wired into the aggregate `arch4u-ruleset.xml` under a new "testing" section, so consumers get it via the main ruleset.
- **Test** `AvoidMixingJunit4AndJunit5Test` + 10 `test-code` cases in `xml/AvoidMixingJunit4AndJunit5.xml`.
- `readme.md` rule table updated with the new rule.

## Detection

The XPath was written against the actual PMD 7.25 Java AST and covers:

- **Imports** (`ImportDeclaration/@PackageName`) — regular and `static` imports, including on-demand.
- **Fully-qualified annotations** (`ClassType[@FullyQualified='true']/@PackageQualifier`) — e.g. the issue's own `@org.junit.Test` mixed with an imported `@ExtendWith`.

JUnit 5 is `org.junit.jupiter.*`; JUnit 4 is `org.junit.*` excluding `org.junit.jupiter.*`. A violation is reported once per top-level class that references both.

### Examples covered by tests
- ✅ Good: pure JUnit 4, pure JUnit 5, fully-qualified pure JUnit 5, no-JUnit class.
- ❌ Violation: mixed imports, JUnit 5 import + fully-qualified JUnit 4 annotation, fully-qualified both without imports, JUnit 4 `@RunWith` + JUnit 5 `@BeforeEach`, mixed static assertion imports.

## Verification

- `mvn test -Dtest=AvoidMixingJunit4AndJunit5Test` → **10/10 pass**.
- `mvn -B -Pqulice clean install` (the CI command) → **BUILD SUCCESS**, including qulice and JaCoCo coverage gates.

Closes #147

https://claude.ai/code/session_012p4bAJd2Ck8Zic6jUuch1y

---
_Generated by [Claude Code](https://claude.ai/code/session_012p4bAJd2Ck8Zic6jUuch1y)_